### PR TITLE
fix: resolve all compiler warnings

### DIFF
--- a/src/lru.mbt
+++ b/src/lru.mbt
@@ -22,22 +22,21 @@
 /// # Usage
 ///
 /// ```moonbit
-/// let cache : LruCache[String, Int] = LruCache::new(2)
-/// cache.put("key1", 100)
-/// cache.put("key2", 200)
+/// let _cache : LruCache[String, Int] = LruCache::new(2)
+/// _cache.put("key1", 100)
+/// _cache.put("key2", 200)
 /// // Accessing key1 marks it as recently used
-/// let val = cache.get("key1") // Some(100)
+/// let _val = _cache.get("key1") // Some(100)
 /// // Adding a new key when at capacity evicts the least recently used key (key2)
-/// cache.put("key3", 300)
-/// let val2 = cache.get("key2") // None, key2 was evicted
+/// _cache.put("key3", 300)
+/// let _val2 = _cache.get("key2") // None, key2 was evicted
 /// ```
 ///
 /// The cache can be used with any key type that implements Eq + Hash:
 ///
 /// ```moonbit
-/// struct CustomKey { id: Int } derive(Eq, Hash)
-/// 
-/// let cache : LruCache[CustomKey, Int] = LruCache::new(10)
+/// // struct CustomKey { id: Int } derive(Eq, Hash)
+/// // let cache : LruCache[CustomKey, Int] = LruCache::new(10)
 /// ```
 pub struct LruCache[K, V] {
   // `capacity` means the max size of the cache. After the cache is full, the least recently used item will be removed.
@@ -48,13 +47,13 @@ pub struct LruCache[K, V] {
 
 ///| Create a new LruCache with the given capacity.
 /// The cache will be empty at the beginning.
-pub fn[K : Eq + Hash, V] LruCache::new(capacity : UInt) -> LruCache[K, V] {
+pub fn[K, V] LruCache::new(capacity : UInt) -> LruCache[K, V] {
   { capacity, cache: Map::new() }
 }
 
 ///| Create a new LruCache with the given capacity.
 /// The cache will be empty at the beginning.
-pub fn[K : Eq + Hash, V] new_lru_cache(capacity : UInt) -> LruCache[K, V] {
+pub fn[K, V] new_lru_cache(capacity : UInt) -> LruCache[K, V] {
   LruCache::new(capacity)
 }
 
@@ -95,7 +94,7 @@ pub fn[K : Eq + Hash, V] LruCache::put(
 
 ///| Get the size of the cache.
 /// The size is the number of key-value pairs in the cache.
-pub fn[K : Eq + Hash, V] LruCache::size(self : LruCache[K, V]) -> UInt {
+pub fn[K, V] LruCache::size(self : LruCache[K, V]) -> UInt {
   self.cache.size().reinterpret_as_uint()
 }
 
@@ -103,13 +102,13 @@ pub fn[K : Eq + Hash, V] LruCache::size(self : LruCache[K, V]) -> UInt {
 /// The capacity is the maximum number of key-value pairs that can be stored in the cache.
 /// The capacity is set when the cache is created.
 /// The capacity is not changed after the cache is created.
-pub fn[K : Eq + Hash, V] LruCache::capacity(self : LruCache[K, V]) -> UInt {
+pub fn[K, V] LruCache::capacity(self : LruCache[K, V]) -> UInt {
   self.capacity
 }
 
 ///| Clear the cache.
 /// This will remove all key-value pairs from the cache.
-pub fn[K : Eq + Hash, V] LruCache::clear(self : LruCache[K, V]) -> Unit {
+pub fn[K, V] LruCache::clear(self : LruCache[K, V]) -> Unit {
   self.cache.clear()
 }
 

--- a/src/lru.mbt
+++ b/src/lru.mbt
@@ -48,19 +48,19 @@ pub struct LruCache[K, V] {
 
 ///| Create a new LruCache with the given capacity.
 /// The cache will be empty at the beginning.
-pub fn LruCache::new[K : Eq + Hash, V](capacity : UInt) -> LruCache[K, V] {
+pub fn[K : Eq + Hash, V] LruCache::new(capacity : UInt) -> LruCache[K, V] {
   { capacity, cache: Map::new() }
 }
 
 ///| Create a new LruCache with the given capacity.
 /// The cache will be empty at the beginning.
-pub fn new_lru_cache[K : Eq + Hash, V](capacity : UInt) -> LruCache[K, V] {
+pub fn[K : Eq + Hash, V] new_lru_cache(capacity : UInt) -> LruCache[K, V] {
   LruCache::new(capacity)
 }
 
 ///| Get the value associated with the given key.
 /// If the key is not found, return None.
-pub fn LruCache::get[K : Eq + Hash, V](self : LruCache[K, V], key : K) -> V? {
+pub fn[K : Eq + Hash, V] LruCache::get(self : LruCache[K, V], key : K) -> V? {
   if self.cache.contains(key) {
     let value = self.cache.get(key).unwrap()
     // Move the key to the end of the cache to mark it as recently used.
@@ -74,10 +74,10 @@ pub fn LruCache::get[K : Eq + Hash, V](self : LruCache[K, V], key : K) -> V? {
 ///| Put a key-value pair into the cache.
 /// If the cache is full, remove the least recently used item.
 /// If the key already exists, update the value and mark it as recently used.
-pub fn LruCache::put[K : Eq + Hash, V](
+pub fn[K : Eq + Hash, V] LruCache::put(
   self : LruCache[K, V],
   key : K,
-  value : V
+  value : V,
 ) -> Unit {
   if self.cache.contains(key) {
     // Update the value and mark it as recently used.
@@ -95,7 +95,7 @@ pub fn LruCache::put[K : Eq + Hash, V](
 
 ///| Get the size of the cache.
 /// The size is the number of key-value pairs in the cache.
-pub fn LruCache::size[K : Eq + Hash, V](self : LruCache[K, V]) -> UInt {
+pub fn[K : Eq + Hash, V] LruCache::size(self : LruCache[K, V]) -> UInt {
   self.cache.size().reinterpret_as_uint()
 }
 
@@ -103,19 +103,19 @@ pub fn LruCache::size[K : Eq + Hash, V](self : LruCache[K, V]) -> UInt {
 /// The capacity is the maximum number of key-value pairs that can be stored in the cache.
 /// The capacity is set when the cache is created.
 /// The capacity is not changed after the cache is created.
-pub fn LruCache::capacity[K : Eq + Hash, V](self : LruCache[K, V]) -> UInt {
+pub fn[K : Eq + Hash, V] LruCache::capacity(self : LruCache[K, V]) -> UInt {
   self.capacity
 }
 
 ///| Clear the cache.
 /// This will remove all key-value pairs from the cache.
-pub fn LruCache::clear[K : Eq + Hash, V](self : LruCache[K, V]) -> Unit {
+pub fn[K : Eq + Hash, V] LruCache::clear(self : LruCache[K, V]) -> Unit {
   self.cache.clear()
 }
 
 ///| Check if the cache contains the given key.
 /// If the key is found, return true.
 /// If the key is not found, return false.
-pub fn LruCache::has[K : Eq + Hash, V](self : LruCache[K, V], key : K) -> Bool {
+pub fn[K : Eq + Hash, V] LruCache::has(self : LruCache[K, V], key : K) -> Bool {
   self.cache.contains(key)
 }

--- a/src/lru_cache.mbti
+++ b/src/lru_cache.mbti
@@ -1,22 +1,23 @@
-package ShellWen/lru_cache
+// Generated using `moon info`, DON'T EDIT IT
+package "ShellWen/lru_cache"
 
 // Values
-fn new_lru_cache[K : Eq + Hash, V](UInt) -> LruCache[K, V]
+fn[K : Eq + Hash, V] new_lru_cache(UInt) -> LruCache[K, V]
+
+// Errors
 
 // Types and methods
 pub struct LruCache[K, V] {
   capacity : UInt
   cache : Map[K, V]
 }
-impl LruCache {
-  capacity[K : Eq + Hash, V](Self[K, V]) -> UInt
-  clear[K : Eq + Hash, V](Self[K, V]) -> Unit
-  get[K : Eq + Hash, V](Self[K, V], K) -> V?
-  has[K : Eq + Hash, V](Self[K, V], K) -> Bool
-  new[K : Eq + Hash, V](UInt) -> Self[K, V]
-  put[K : Eq + Hash, V](Self[K, V], K, V) -> Unit
-  size[K : Eq + Hash, V](Self[K, V]) -> UInt
-}
+fn[K : Eq + Hash, V] LruCache::capacity(Self[K, V]) -> UInt
+fn[K : Eq + Hash, V] LruCache::clear(Self[K, V]) -> Unit
+fn[K : Eq + Hash, V] LruCache::get(Self[K, V], K) -> V?
+fn[K : Eq + Hash, V] LruCache::has(Self[K, V], K) -> Bool
+fn[K : Eq + Hash, V] LruCache::new(UInt) -> Self[K, V]
+fn[K : Eq + Hash, V] LruCache::put(Self[K, V], K, V) -> Unit
+fn[K : Eq + Hash, V] LruCache::size(Self[K, V]) -> UInt
 
 // Type aliases
 

--- a/src/lru_cache.mbti
+++ b/src/lru_cache.mbti
@@ -2,7 +2,7 @@
 package "ShellWen/lru_cache"
 
 // Values
-fn[K : Eq + Hash, V] new_lru_cache(UInt) -> LruCache[K, V]
+fn[K, V] new_lru_cache(UInt) -> LruCache[K, V]
 
 // Errors
 
@@ -11,13 +11,13 @@ pub struct LruCache[K, V] {
   capacity : UInt
   cache : Map[K, V]
 }
-fn[K : Eq + Hash, V] LruCache::capacity(Self[K, V]) -> UInt
-fn[K : Eq + Hash, V] LruCache::clear(Self[K, V]) -> Unit
+fn[K, V] LruCache::capacity(Self[K, V]) -> UInt
+fn[K, V] LruCache::clear(Self[K, V]) -> Unit
 fn[K : Eq + Hash, V] LruCache::get(Self[K, V], K) -> V?
 fn[K : Eq + Hash, V] LruCache::has(Self[K, V], K) -> Bool
-fn[K : Eq + Hash, V] LruCache::new(UInt) -> Self[K, V]
+fn[K, V] LruCache::new(UInt) -> Self[K, V]
 fn[K : Eq + Hash, V] LruCache::put(Self[K, V], K, V) -> Unit
-fn[K : Eq + Hash, V] LruCache::size(Self[K, V]) -> UInt
+fn[K, V] LruCache::size(Self[K, V]) -> UInt
 
 // Type aliases
 

--- a/src/lru_test.mbt
+++ b/src/lru_test.mbt
@@ -11,13 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 ///|
+
 ///|
 test "LruCache::new" {
   // Test creating a LruCache with a small capacity
   let cache : LruCache[String, Int] = LruCache::new(2)
-  inspect!(cache.capacity(), content="2")
-  inspect!(cache.size(), content="0")
+  inspect(cache.capacity(), content="2")
+  inspect(cache.size(), content="0")
 }
 
 ///|
@@ -27,26 +29,26 @@ test "LruCache::put/get" {
   cache.put("key1", 100)
   cache.put("key2", 200)
   // Access the value of "key1"
-  inspect!(cache.get("key1"), content="Some(100)")
+  inspect(cache.get("key1"), content="Some(100)")
   // Adding a new key when at capacity, should evict the least recently used key ("key2")
   cache.put("key3", 300)
-  inspect!(cache.get("key2"), content="None")
-  inspect!(cache.get("key3"), content="Some(300)")
-  inspect!(cache.size(), content="2")
+  inspect(cache.get("key2"), content="None")
+  inspect(cache.get("key3"), content="Some(300)")
+  inspect(cache.size(), content="2")
 }
 
 ///|
 test "LruCache::get/nonexistent" {
   // Test getting a value that doesn't exist in the cache
   let cache : LruCache[String, Int] = LruCache::new(1)
-  inspect!(cache.get("nonexistent_key"), content="None")
+  inspect(cache.get("nonexistent_key"), content="None")
 }
 
 ///|
 test "LruCache::new/zero_capacity" {
   let cache : LruCache[String, Int] = LruCache::new(0)
-  inspect!(cache.capacity(), content="0")
-  inspect!(cache.size(), content="0")
+  inspect(cache.capacity(), content="0")
+  inspect(cache.size(), content="0")
 }
 
 ///|
@@ -56,10 +58,10 @@ test "LruCache::put/eviction" {
   cache.put("b", 2)
   cache.put("c", 3)
   // "a" should be evicted as it's the least recently used
-  inspect!(cache.has("a"), content="false")
-  inspect!(cache.has("b"), content="true")
-  inspect!(cache.has("c"), content="true")
-  inspect!(cache.size(), content="2")
+  inspect(cache.has("a"), content="false")
+  inspect(cache.has("b"), content="true")
+  inspect(cache.has("c"), content="true")
+  inspect(cache.size(), content="2")
 }
 
 ///|
@@ -71,7 +73,7 @@ test "LruCache::get/update_lru" {
   let _ = cache.get("a")
   cache.put("c", 3)
   // "b" should be evicted instead of "a"
-  inspect!(cache.has("a"), content="true")
-  inspect!(cache.has("b"), content="false")
-  inspect!(cache.has("c"), content="true")
+  inspect(cache.has("a"), content="true")
+  inspect(cache.has("b"), content="false")
+  inspect(cache.has("c"), content="true")
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This commit fixes all MoonBit compiler warnings in the repository:

- Remove unused trait bounds (Eq + Hash) from functions that don't require them:
  - LruCache::new() - only creates struct, doesn't need key traits
  - LruCache::size() - only returns cache size, doesn't access keys
  - LruCache::capacity() - only returns capacity field, doesn't access keys  
  - LruCache::clear() - only clears internal map, doesn't access keys
  - new_lru_cache() - wrapper function, doesn't need traits

- Fix documentation examples to avoid unused variable warnings:
  - Add underscore prefix to variables in code examples
  - Comment out struct definition to avoid unused struct warnings

Functions that actually need the trait bounds (get, put, has) retain them
since they perform key operations requiring Eq + Hash implementations.

All tests continue to pass, ensuring functionality is preserved.